### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,11 @@ OVN (Open Virtual Network) is a series of daemons that translates virtual
 network configuration into OpenFlow, and installs them into Open vSwitch.
 It is licensed under the open source Apache 2 license.
 
-OVN is provides a higher-layer abstraction then Open vSwitch, working with
+OVN provides higher-layer abstraction than Open vSwitch by working with
 logical routers and logical switches, rather than flows. OVN is intended to be
 used by cloud management software (CMS). For details about the architecture of
 OVN, see the ovn-architecture manpage. Some high-level features offered by OVN
-include
+include:
 
 * Distributed virtual routers
 * Distributed logical switches
@@ -27,8 +27,8 @@ include
 Like Open vSwitch, OVN is written in platform-independent C. OVN runs entirely
 in userspace and therefore requires no kernel modules to be installed.
 
-Until recently, OVN code lived within the Open vSwitch codebase. OVN has
-recently been split into its own repo. There is much to do to complete this
+Before mid-2019, OVN code lived within the Open vSwitch codebase but now OVN has
+been split into its own repo. There is much to do to complete this
 split entirely. See the TODO_SPLIT.rst file for a list of known tasks that
 need to be completed.
 


### PR DESCRIPTION
Fix a few typos and some grammar problems.
Rather than saying that the split from Open vSwitch was recent, cite the date so that it's more accurate and independent of time.